### PR TITLE
Add Context7 and DuckDB MCP servers

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,6 +3,18 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "mcp-server-motherduck": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-motherduck",
+        "--db-path",
+        ":memory:"
+      ]
     }
   }
 }


### PR DESCRIPTION
closes #13

## Summary

This PR adds two MCP server configurations to `.vscode/mcp.json` for discoverability and quick local testing:

- `context7` — points to the Context7 remote MCP HTTP endpoint: `https://mcp.context7.com/mcp`. This entry uses the unauthenticated default URL so a user with access can call the endpoint directly. If you want higher rate limits or private data, you can add an API key header or switch to the local stdio `npx` installation described in the Context7 README.

- `mcp-server-motherduck` — a local command-based configuration that launches MotherDuck's DuckDB MCP server in-memory by default using `uvx mcp-server-motherduck --db-path :memory:`. This avoids requiring a token for basic local testing. To connect to an actual MotherDuck account or persistent DB, run the server with `--db-path md:` and provide a `--motherduck-token` (or set up the token in your client). See the MotherDuck README for production recommendations and `--saas-mode` guidance.

## Why this change

- Makes Context7 and a DuckDB/MotherDuck MCP server easily discoverable by tools and IDEs that read `.vscode/mcp.json` in the workspace.
- Provides sensible, non-auth defaults so contributors can try them locally without creating service credentials.
