### PR TITLE
Add prompt files

### DIFF
--- a/.github/prompts/Explain-code.prompt.md
+++ b/.github/prompts/Explain-code.prompt.md
@@ -1,0 +1,19 @@
+---
+mode: 'agent'
+description: 'Generate a clear code explanation with examples'
+---
+
+Explain the following code in a clear, beginner-friendly way:
+
+Code to explain: ${input:code:Paste your code here}
+Target audience: ${input:audience:Who is this explanation for? (e.g., beginners, intermediate developers, etc.)}
+
+Please provide:
+
+* A brief overview of what the code does
+* A step-by-step breakdown of the main parts
+* Explanation of any key concepts or terminology
+* A simple example showing how it works
+* Common use cases or when you might use this approach
+
+Use clear, simple language and avoid unnecessary jargon.

--- a/.github/prompts/Learn-a-package.prompt.md
+++ b/.github/prompts/Learn-a-package.prompt.md
@@ -1,0 +1,20 @@
+---
+mode: 'agent'
+description: 'Learn about a library'
+---
+
+I'd like to learn about a library based on the latest docs and code.
+
+Use clear, simple language and avoid unnecessary jargon.
+
+Always start with:
+
+* An overview of what the library is
+* Explanation of core concepts and terminology
+* Links to official documentation
+
+Library to explain: ${input:code:Enter the library name here}
+Target audience: ${input:audience:Who is this explanation for? (e.g., beginners, intermediate developers, etc.)}
+
+
+Use context7

--- a/.github/prompts/Update-PR-description.prompt.md
+++ b/.github/prompts/Update-PR-description.prompt.md
@@ -1,0 +1,16 @@
+---
+mode: 'agent'
+description: 'Update pull request description'
+---
+
+Please update the description of the active pull request to reflect:
+
+* A brief overview of what the code changes are
+* The latest changes
+* Unresolved review comments
+
+Use clear, simple language and avoid unnecessary jargon.
+
+Use markdown section headers (e.g. "## Overview" and "## Changes").
+
+ALWAYS use tools from the GitHub MCP server.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ This repository demonstrates the use of GitHub Copilot in VS Code and on GitHub.
 - [uv](https://docs.astral.sh/uv/) to manage python environments
 - [Docker](https://www.docker.com/) (optional) to run the local version of the GitHub MCP server
 
+## MCP servers
+
+- [GitHub](https://github.com/github/github-mcp-server)
+- [Context7](https://github.com/upstash/context7)
+- [DuckDB (MotherDuck MCP server)](https://github.com/motherduckdb/mcp-server-motherduck)
+
 ## Setup
 
 1. Clone the repository
@@ -29,29 +35,25 @@ This repository demonstrates the use of GitHub Copilot in VS Code and on GitHub.
 
 3. Start the MCP servers configured in `.vscode/mcp.json`
 
-## Environment Variables
+### Environment Variables
 
 | Variable                     | Description                                                                                                                                                                                     | Required |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | GITHUB_PERSONAL_ACCESS_TOKEN | GitHub Personal Access Token for authentication with GitHub MCP server (only required for a local server). Create this token in your GitHub Developer Settings with the minimal permissions you'd like the MCP server to have. | No      |
 
-## Project Structure
-
-TODO: Add description of key files and directories
-
 ## Resources
 
 - [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution) - Anthropic's AI principles and ethical guidelines
 - [Copilot Tips and Tricks](https://code.visualstudio.com/docs/copilot/copilot-tips-and-tricks) - Tips and best practices for using GitHub Copilot in VS Code
+- [VS Code MCP Servers](https://code.visualstudio.com/mcp) - A curated list of MCP servers by VS Code
 - [Awesome GitHub Copilot Customizations](https://github.com/github/awesome-copilot) - Collection of community-contributed instructions, prompts, and configurations for GitHub Copilot.
-- [Model Context Protocol Servers](https://github.com/modelcontextprotocol/servers) - Collection of official and community-maintained MCP servers
+- [Model Context Protocol Servers](https://github.com/modelcontextprotocol/servers) - Collection of reference and community-maintained MCP servers
 
 ## Documentation
 
 - [GitHub Copilot](https://docs.github.com/en/copilot) - Overview of GitHub Copilot
 - [GitHub Copilot in VS Code](https://code.visualstudio.com/docs/copilot/overview) - Overview and guide for using GitHub Copilot in Visual Studio Code
 - [MCP Server Documentation](https://modelcontextprotocol.io/introduction) - Introduction to Model Context Protocol
-- [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official GitHub Model Context Protocol Server repository
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This repository demonstrates the use of GitHub Copilot in VS Code and on GitHub.
 
 ## Features
 
-- Use of Model Context Protocol (MCP) servers
-- Use of Copilot for code review on PRs
+- Model Context Protocol (MCP) servers
+- Copilot for code review on PRs
+- Custom [prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files)
 
 ## Prerequisites
 


### PR DESCRIPTION
This pull request adds a set of repository prompts under `.github/prompts/` used by automated agents. The changes introduce prompt files and supporting metadata to help onboard and standardize agent behaviors.

Latest changes

- Added `Update-PR-description.prompt.md` with instructions for updating PR descriptions when requested by agents.
- Created the `.github/prompts/` folder and placed the new prompt file inside it.
